### PR TITLE
Adding in more options for string encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ datacleaner can be used on the command line. Use `--help` to see its usage instr
 
 ```
 usage: datacleaner [-h] [-cv CROSS_VAL_FILENAME] [-o OUTPUT_FILENAME]
-                   [-cvo CV_OUTPUT_FILENAME] [-is INPUT_SEPARATOR] [-en ENCODER]
+                   [-cvo CV_OUTPUT_FILENAME] [-is INPUT_SEPARATOR]
                    [-os OUTPUT_SEPARATOR] [--drop-nans] [--version]
                    INPUT_FILENAME
 
@@ -63,7 +63,6 @@ optional arguments:
                         Data file to output the cleaned cross-validation data
                         set to
   -is INPUT_SEPARATOR   Column separator for the input file(s) (default: \t)
-  -en ENCODER           Name of encoder to use (from category_encoders) (default: None)
   -os OUTPUT_SEPARATOR  Column separator for the output file(s) (default: \t)
   --drop-nans           Drop all rows that have a NaN in any column (default:
                         False)
@@ -97,8 +96,11 @@ autoclean(input_dataframe, drop_nans=False, copy=False)
     copy: bool
         Make a copy of the data set (default: False)
         
-    encoder: str
-        The name of an encoder from category_encoders to use (default: None)
+    encoder: category_encoders transformer
+        The a valid category_encoders transformer which is passed an inferred cols list. Default (None: LabelEncoder)
+
+    encoder_kwargs: category_encoders
+        The a valid sklearn transformer to encode categorical features. Default (None)
     
     Returns
     ----------
@@ -128,8 +130,11 @@ autoclean_cv(training_dataframe, testing_dataframe, drop_nans=False, copy=False)
     copy: bool
         Make a copy of the data set (default: False)
         
-    encoder: str
-        The name of an encoder from category_encoders to use (default: None)
+    encoder: category_encoders transformer
+        The a valid category_encoders transformer which is passed an inferred cols list. Default (None: LabelEncoder)
+
+    encoder_kwargs: category_encoders
+        The a valid sklearn transformer to encode categorical features. Default (None)
     
     Returns
     ----------

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ datacleaner can be used on the command line. Use `--help` to see its usage instr
 
 ```
 usage: datacleaner [-h] [-cv CROSS_VAL_FILENAME] [-o OUTPUT_FILENAME]
-                   [-cvo CV_OUTPUT_FILENAME] [-is INPUT_SEPARATOR]
+                   [-cvo CV_OUTPUT_FILENAME] [-is INPUT_SEPARATOR] [-en ENCODER]
                    [-os OUTPUT_SEPARATOR] [--drop-nans] [--version]
                    INPUT_FILENAME
 
@@ -63,6 +63,7 @@ optional arguments:
                         Data file to output the cleaned cross-validation data
                         set to
   -is INPUT_SEPARATOR   Column separator for the input file(s) (default: \t)
+  -en ENCODER           Name of encoder to use (from category_encoders) (default: None)
   -os OUTPUT_SEPARATOR  Column separator for the output file(s) (default: \t)
   --drop-nans           Drop all rows that have a NaN in any column (default:
                         False)
@@ -95,6 +96,9 @@ autoclean(input_dataframe, drop_nans=False, copy=False)
     
     copy: bool
         Make a copy of the data set (default: False)
+        
+    encoder: str
+        The name of an encoder from category_encoders to use (default: None)
     
     Returns
     ----------
@@ -123,6 +127,9 @@ autoclean_cv(training_dataframe, testing_dataframe, drop_nans=False, copy=False)
     
     copy: bool
         Make a copy of the data set (default: False)
+        
+    encoder: str
+        The name of an encoder from category_encoders to use (default: None)
     
     Returns
     ----------

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ or Twitter: https://twitter.com/randal_olson
 This project is hosted at https://github.com/rhiever/datacleaner
 ''',
     zip_safe=True,
-    install_requires=['pandas', 'scikit-learn', 'update_checker', 'category_encoders'],
+    install_requires=['pandas', 'scikit-learn', 'update_checker'],
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ or Twitter: https://twitter.com/randal_olson
 This project is hosted at https://github.com/rhiever/datacleaner
 ''',
     zip_safe=True,
-    install_requires=['pandas', 'scikit-learn', 'update_checker'],
+    install_requires=['pandas', 'scikit-learn', 'update_checker', 'category_encoders'],
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',


### PR DESCRIPTION
Here is a first stab at an implementation of a no-extra-dependencies version to fix issue #3. If basically just takes in an optional encoder object in each script, as well as kwargs for it (if required), and then passes it the list of object columns in addition to the passed kwargs.  
